### PR TITLE
Add URL and BugReports to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,8 @@ Description: A set of tools for parsing, manipulating, and graphing data classif
 Depends: R (>= 3.0.2)
 License: GPL-2 | GPL-3
 LazyData: true
+URL: https://grunwaldlab.github.io/metacoder_documentation/
+BugReports: https://github.com/grunwaldlab/metacoder/issues
 Imports: stringr, ggplot2, igraph, scales, grid, taxize, seqinr,
         reshape2, zoo, traits, RColorBrewer, RCurl, ape, reshape,
         stats, grDevices, utils, lazyeval, dplyr, magrittr, readr


### PR DESCRIPTION
This makes it easier for users to access the documentation from the CRAN page.
