### PR TITLE
Updated phyloseq tutorial to include otu ids.

### DIFF
--- a/scratch/issue_141--phyloseq_converter.Rmd
+++ b/scratch/issue_141--phyloseq_converter.Rmd
@@ -81,7 +81,8 @@ obj <- parse_phyloseq(phy)
 # Convert counts to proportions
 obj$data$otu_table <- calc_obs_props(obj,
                                      dataset = "otu_table",
-                                     cols = obj$data$sam_data$sample_ids)
+                                     cols = obj$data$sam_data$sample_ids,
+                                     other_cols = TRUE)
 
 # Calculate per-taxon proportions 
 obj$data$tax_table <- calc_taxon_abund(obj, 
@@ -92,7 +93,8 @@ obj$data$tax_table <- calc_taxon_abund(obj,
 obj$data$diff_table <- compare_treatments(obj,
                                           dataset = "tax_table",
                                           sample_ids = obj$data$sam_data$sample_ids,
-                                          treatments = obj$data$sam_data$status)
+                                          treatments = obj$data$sam_data$status,
+                                          other_cols = TRUE)
 
 # Plot differneces
 color_interval <- c(-5, 5) # The range of values (log 2 ratio of median proportion) to display


### PR DESCRIPTION
Added the _other_cols = TRUE_ parameter to calc_obs_props and compare_treatments calls.  This will help preserve the otu_id column when handling the data.  Resolves #219