### PR TITLE
fixed bug in calc_diff_abund_deseq2

### DIFF
--- a/R/calculations--differential_abundance.R
+++ b/R/calculations--differential_abundance.R
@@ -115,7 +115,7 @@ calc_diff_abund_deseq2 <- function(obj, data, cols, groups, other_cols = FALSE,
   other_cols <- get_taxmap_other_cols(obj, data, cols, other_cols)
   
   # Get every combination of groups to compare
-  combinations <- t(utils::combn(unique(groups), 2))
+  combinations <- t(utils::combn(unique(as.character(groups)), 2))
   combinations <- lapply(seq_len(nrow(combinations)), function(i) combinations[i, ])
   
   # Format data for DESeq2


### PR DESCRIPTION
Hi,
Great package! I found a bug in the `calc_diff_abund_deseq2` that prevents the use of factors as grouping variables.  

It throws an error:

```
Error in cleanContrast(object, contrast, expanded = isExpanded, listValues = listValues,  : 
  2 and 1 should be levels of group such that group_2_vs_M and group_1_vs_M are contained in 'resultsNames(object)'
``` 
("M" is the name of my first factor here). I figured out it's because the `DESeq2::results` function requires the names of the factors as arguments to `contrast`, but instead the function is feeding it the factors directly. It seems to work fine if you just convert the grouping variable back to a character vector before feeding the combinations to `DESeq2::result` or `lfcShrink`.